### PR TITLE
removed /etc/samba volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,6 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 COPY samba.sh /usr/bin/
 
-VOLUME ["/etc/samba"]
-
 EXPOSE 137/udp 138/udp 139 445
 
 ENTRYPOINT ["samba.sh"]


### PR DESCRIPTION
/etc/samba/smb.conf is repopulated at every start anyway and not having the volume would allow people to override the default smb.conf in their Dockerfiles.