### PR TITLE
move samba.sh to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     echo '' >>/etc/samba/smb.conf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
-COPY samba.sh /usr/bin/
+COPY samba.sh /usr/local/bin/
 
 VOLUME ["/etc/samba"]
 

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,7 +25,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     echo '' >>/etc/samba/smb.conf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
-COPY samba.sh /usr/bin/
+COPY samba.sh /usr/local/bin/
 
 VOLUME ["/etc/samba"]
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -25,7 +25,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     echo '' >>/etc/samba/smb.conf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
-COPY samba.sh /usr/bin/
+COPY samba.sh /usr/local/bin/
 
 VOLUME ["/etc/samba"]
 


### PR DESCRIPTION
`samba.sh` is not distributed by the system's package manager and therefore be located in `/usr/local/bin`.