### PR TITLE
Remove traces of comment argument in -s argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ OR set local storage:
         -p          Set ownership and permissions on the shares
         -r          Disable recycle bin for shares
         -s "<name;/path>[;browse;readonly;guest;users;admins;wl]" Config a share
-                    required arg: "<name>;<comment>;</path>"
+                    required arg: "<name>;</path>"
                     <name> is how it's called for clients
                     <path> path to share
                     NOTE: for the default values, just leave blank


### PR DESCRIPTION
Just a slight typo fix in the readme which contained traces of the comment argument for shares.