### PR TITLE
Force minimum of SMB2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN export DEBIAN_FRONTEND='noninteractive' && \
     echo '   vfs objects = recycle' >>/etc/samba/smb.conf && \
     echo '   recycle:keeptree = yes' >>/etc/samba/smb.conf && \
     echo '   recycle:versions = yes' >>/etc/samba/smb.conf && \
+    echo '   min protocol = SMB2' >>/etc/samba/smb.conf && \
     echo '' >>/etc/samba/smb.conf && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
This change forces a minimum of SMB2 by default as recommended here (a statement which comes from Microsoft): https://blogs.technet.microsoft.com/filecab/2016/09/16/stop-using-smb1/

See also https://askubuntu.com/questions/546743/how-to-force-smb2-protocol-in-samba.