### PR TITLE
Adding whitespace around = in global config options parse (#76)

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -37,7 +37,7 @@ charmap() { local chars="$1" file=/etc/samba/smb.conf
 # Arguments:
 #   option) raw option
 # Return: line added to smb.conf (replaces existing line with same key)
-global() { local key="${1%%=*}" value="${1##*=}" file=/etc/samba/smb.conf
+global() { local key="${1%% = *}" value="${1##* = }" file=/etc/samba/smb.conf
     if grep -qE '^\s*'"$key" "$file"; then
         sed -i 's|^\s*'"$key"'.*|   '"$key = $value"'|' "$file"
     else


### PR DESCRIPTION
https://www.samba.org/samba/docs/man/manpages-3/smb.conf.5.html

Socket options:

> To specify an argument use the syntax SOME_OPTION = VALUE for example SO_SNDBUF = 8192. Note that you must not have any spaces before or after the = sign.

To distinguish option arguments from global options, the global options have spaces surrounding the = but arguments do not.
The options parsing has been altered to take this into account.