### PR TITLE
Fix(group): groupmod the users group

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -193,7 +193,7 @@ The 'command' (if provided and valid) will be run instead of samba
 }
 
 [[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID -o smbuser
-[[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o smbuser
+[[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o users
 
 while getopts ":hc:g:i:nprs:Su:Ww:" opt; do
     case "$opt" in


### PR DESCRIPTION
smbuser is assigned to the users group, change the id of the users group instead of the smbuser group.
Resolves https://github.com/dperson/samba/issues/79