### PR TITLE
Use more retries instead of a custom cycle to speed up healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY samba.sh /usr/bin/
 
 EXPOSE 137/udp 138/udp 139 445
 
-HEALTHCHECK --interval=60s --timeout=15s \
+HEALTHCHECK --retries=6 \
              CMD smbclient -L '\\localhost\' -U 'guest%' -m SMB3
 
 VOLUME ["/etc/samba"]

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -37,7 +37,7 @@ RUN ["cross-build-end"]
 
 COPY samba.sh /usr/bin/
 
-HEALTHCHECK --interval=60s --timeout=15s \
+HEALTHCHECK --retries=6 \
              CMD smbclient -L '\\localhost\' -U 'guest%' -m SMB3
 
 EXPOSE 137/udp 138/udp 139 445


### PR DESCRIPTION
 (30s check, 30s timeout) vs (60s check, 15s timeout)

It would still check every thirty or sixty seconds, but would give a 30-45s better loading time for faster machines.