### PR TITLE
Add -I include parameter to samba.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ OR set local storage:
                     required arg: "<workgroup>"
                     <workgroup> for samba
         -W          Allow access wide symbolic links
+        -I          Add an include option at the end of the smb.conf
+                    required arg: "<include file path>"
+                    <include file path> in the container, e.g. a bind mount
 
     The 'command' (if provided and valid) will be run instead of samba
 
@@ -82,6 +85,7 @@ ENVIRONMENT VARIABLES (only available with `docker run`)
  * `WORKGROUP` - As above, set workgroup
  * `USERID` - Set the UID for the samba server
  * `GROUPID` - Set the GID for the samba server
+ * `INCLUDE` - As above, add a smb.conf include
 
 **NOTE**: if you enable nmbd (via `-n` or the `NMBD` environment variable), you
 will also want to expose port 137 and 138 with `-p 137:137/udp -p 138:138/udp`.


### PR DESCRIPTION
This PR adds a new parameter -I to samba.sh. The user can use this to add additional configuration to smb.conf, in my example a TimeMachine share with not yet supported config options.

Example:

```yaml
# docker-compose.yml
version: '3.4'

services:
  samba:
    volumes:
      - /mnt/shared:/mnt/shared
      - /mnt/timemachine:/mnt/timemachine
      - ./timemachine.conf:/etc/samba/timemachine.conf:ro
    ports:
      - 445:445
    command: >
      -w WORKGROUP
      -g "fruit:model = RackMac"
      -g "fruit:advertise_fullsync = true"
      -g "fruit:aapl = true"
      -s "shared;/mnt/shared/;yes;no;no;user"
      -I "/etc/samba/timemachine.conf"
```

```ini
; timemachine.conf
[TimeMachine]
    path = /mnt/timemachine
    browsable = no
    vfs objects = catia fruit streams_xattr
    guest ok = no
    fruit:aapl = yes
    valid users = user
    read only = no
```