### PR TITLE
Add --no-process-group flag to smbd

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -242,5 +242,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS </dev/null
+    exec ionice -c 3 smbd -FS --no-process-group </dev/null
 fi


### PR DESCRIPTION
Latest Samba on Alpine fails with "Failed to create session" without
this flag.