### PR TITLE
Edit example drive name configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Any of the commands can be run at creation with `docker run` or later with
                 -u "example2;badpass" \
                 -s "public;/share" \
                 -s "users;/srv;no;no;no;example1,example2" \
-                -s "example1 private;/example1;no;no;no;example1" \
-                -s "example2 private;/example2;no;no;no;example2"
+                -s "example1's private folder;/example1;no;no;no;example1" \
+                -s "example2's private folder;/example2;no;no;no;example2"
 
 # User Feedback
 


### PR DESCRIPTION
In the readme example I got confused with the `-s "example1 private;/example1;no;no;no;example1"` drive name as I assumed `"private" `was configuration and not part of a drive name with spaces. 

So I am amending private folder names in order to avoid confusion with configuration format.