### PR TITLE
fixed typo of "recycle:maxsize" option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   vfs objects = acl_xattr catia fruit recycle streams_xattr' \
                 >>$file && \
     echo '   recycle:keeptree = yes' >>$file && \
-    echo '   recycle:maxsixe = 0' >>$file && \
+    echo '   recycle:maxsize = 0' >>$file && \
     echo '   recycle:repository = .deleted' >>$file && \
     echo '   recycle:versions = yes' >>$file && \
     echo '' >>$file && \


### PR DESCRIPTION
Fixed typo of the parameter for samba.sh in Dockerfile.

`recycle:maxsixe` must be `recycle.maxsize`.

