### PR TITLE
Adds tzdata to properly handle timezones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install samba
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini && \
+    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -4,7 +4,7 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install samba
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini && \
+    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -4,7 +4,7 @@ MAINTAINER David Personette <dperson@gmail.com>
 
 # Install samba
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini && \
+    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \


### PR DESCRIPTION
This makes it possible to for example use `Europe/Brussels` as the timezone. Reason for this is that without it it seems to be impossible to set it to the correct timezone:

```
bash-5.0# TZ=CET
bash-5.0# date
Mon Oct 28 21:16:38 CET 2019

bash-5.0# TZ=Europe/Brussels
bash-5.0# date
Mon Oct 28 21:16:59 UTC 2019

bash-5.0# apk add tzdata
(1/1) Installing tzdata (2019c-r0)
Executing busybox-1.30.1-r2.trigger
OK: 55 MiB in 64 packages

bash-5.0# TZ=Europe/Brussels
bash-5.0# date
Mon Oct 28 22:17:47 CET 2019
```