### PR TITLE
These updates should increase smb performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN apk --no-cache --no-progress upgrade && \
     echo '   recycle:maxsize = 0' >>$file && \
     echo '   recycle:repository = .deleted' >>$file && \
     echo '   recycle:versions = yes' >>$file && \
+    echo '   os level = 255' >>$file && \
+    echo '   preferred master = yes' >>$file && \
+    echo '   domain master = yes' >>$file && \
     echo '' >>$file && \
     echo '   # Security' >>$file && \
     echo '   client ipc max protocol = SMB3' >>$file && \


### PR DESCRIPTION
- os level = 255
```
Who becomes the master browser is determined by an election process using broadcasts. Each election packet contains a number of parameters that determine what precedence (bias) a host should have in the election. By default Samba uses a low precedence and thus loses elections to just about every Windows network server or client.

If you want Samba to win elections, set the os level global option in smb.conf to a higher number. It defaults to 20. Using 34 would make it win all elections over every other system (except other Samba systems).

An os level of two would make it beat Windows for Workgroups and Windows 9x/Me, but not MS Windows NT/200x Server. An MS Windows NT/200x Server domain controller uses level 32. The maximum os level is 255.
```

- preferred master = yes 
```
If you want Samba to force an election on startup, set the preferred master global option in smb.conf to yes. Samba will then have a slight advantage over other potential master browsers that are not preferred master browsers.
```

- domain master = yes

```
The domain master browser is responsible for collating the browse lists of multiple subnets so browsing can occur between subnets. You can make Samba act as the domain master browser by setting domain master = yes in smb.conf. By default it will not be a domain master browser.
```