### PR TITLE
Add options to not force the user or group to a single user.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ OR set local storage:
         -I          Add an include option at the end of the smb.conf
                     required arg: "<include file path>"
                     <include file path> in the container, e.g. a bind mount
+        -f          No forcing the user to be smbuser
 
     The 'command' (if provided and valid) will be run instead of samba
 
@@ -88,6 +89,7 @@ ENVIRONMENT VARIABLES
  * `USERID` - Set the UID for the samba server
  * `GROUPID` - Set the GID for the samba server
  * `INCLUDE` - As above, add a smb.conf include
+ * `NOFORCEUSER` - No forcing the user to be smbuser
 
 **NOTE**: if you enable nmbd (via `-n` or the `NMBD` environment variable), you
 will also want to expose port 137 and 138 with `-p 137:137/udp -p 138:138/udp`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ OR set local storage:
                     required arg: "<include file path>"
                     <include file path> in the container, e.g. a bind mount
         -f          No forcing the user to be smbuser
+        -F          No forcing the group to be smb
 
     The 'command' (if provided and valid) will be run instead of samba
 
@@ -90,6 +91,7 @@ ENVIRONMENT VARIABLES
  * `GROUPID` - Set the GID for the samba server
  * `INCLUDE` - As above, add a smb.conf include
  * `NOFORCEUSER` - No forcing the user to be smbuser
+ * `NOFORCEGROUP` - No forcing the group to be smb
 
 **NOTE**: if you enable nmbd (via `-n` or the `NMBD` environment variable), you
 will also want to expose port 137 and 138 with `-p 137:137/udp -p 138:138/udp`.

--- a/samba.sh
+++ b/samba.sh
@@ -173,6 +173,14 @@ noforceuser() { local file=/etc/samba/smb.conf
     sed -i 's/\(   force user = smbuser\)/#\1/' $file
 }
 
+### noforcegroup: Disable forcing group to smb
+# Arguments:
+#   none)
+# Return: result
+noforcegroup() { local file=/etc/samba/smb.conf
+    sed -i 's/\(   force group = smb\)/#\1/' $file
+}
+
 ### usage: Help
 # Arguments:
 #   none)
@@ -220,6 +228,7 @@ Options (fields in '[]' are optional, '<>' are required):
                 required arg: \"<include file path>\"
                 <include file path> in the container, e.g. a bind mount
     -f          Disable forcing the user to smbuser.
+    -F          Disable forcing the group to smb.
 
 The 'command' (if provided and valid) will be run instead of samba
 " >&2
@@ -229,7 +238,7 @@ The 'command' (if provided and valid) will be run instead of samba
 [[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID -o smbuser
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o smb
 
-while getopts ":hc:g:i:nprs:Su:Ww:I:f:" opt; do
+while getopts ":hc:g:i:nprs:Su:Ww:I:Ff:" opt; do
     case "$opt" in
         h) usage ;;
         c) charmap "$OPTARG" ;;
@@ -245,6 +254,7 @@ while getopts ":hc:g:i:nprs:Su:Ww:I:f:" opt; do
         W) widelinks ;;
         I) include "$OPTARG" ;;
         f) noforceuser ;;
+        F) noforcegroup ;;
         "?") echo "Unknown option: -$OPTARG"; usage 1 ;;
         ":") echo "No argument value for option: -$OPTARG"; usage 2 ;;
     esac
@@ -268,6 +278,7 @@ done < <(env | awk '/^USER[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')
 [[ "${WIDELINKS:-""}" ]] && widelinks
 [[ "${INCLUDE:-""}" ]] && include "$INCLUDE"
 [[ "${NOFORCEUSER:-""}" ]] && noforceuser
+[[ "${NOFORCEGROUP:-""}" ]] && noforcegroup
 [[ "${PERMISSIONS:-""}" ]] && perms
 
 if [[ $# -ge 1 && -x $(which $1 2>&-) ]]; then

--- a/samba.sh
+++ b/samba.sh
@@ -165,6 +165,14 @@ widelinks() { local file=/etc/samba/smb.conf \
     sed -i 's/\(follow symlinks = yes\)/'"$replace"'/' $file
 }
 
+### noforceuser: Disable forcing user to smbuser
+# Arguments:
+#   none)
+# Return: result
+noforceuser() { local file=/etc/samba/smb.conf
+    sed -i 's/\(   force user = smbuser\)/#\1/' $file
+}
+
 ### usage: Help
 # Arguments:
 #   none)
@@ -211,6 +219,7 @@ Options (fields in '[]' are optional, '<>' are required):
     -I          Add an include option at the end of the smb.conf
                 required arg: \"<include file path>\"
                 <include file path> in the container, e.g. a bind mount
+    -f          Disable forcing the user to smbuser.
 
 The 'command' (if provided and valid) will be run instead of samba
 " >&2
@@ -220,7 +229,7 @@ The 'command' (if provided and valid) will be run instead of samba
 [[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID -o smbuser
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o smb
 
-while getopts ":hc:g:i:nprs:Su:Ww:I:" opt; do
+while getopts ":hc:g:i:nprs:Su:Ww:I:f:" opt; do
     case "$opt" in
         h) usage ;;
         c) charmap "$OPTARG" ;;
@@ -235,6 +244,7 @@ while getopts ":hc:g:i:nprs:Su:Ww:I:" opt; do
         w) workgroup "$OPTARG" ;;
         W) widelinks ;;
         I) include "$OPTARG" ;;
+        f) noforceuser ;;
         "?") echo "Unknown option: -$OPTARG"; usage 1 ;;
         ":") echo "No argument value for option: -$OPTARG"; usage 2 ;;
     esac
@@ -257,6 +267,7 @@ done < <(env | awk '/^USER[0-9=_]/ {sub (/^[^=]*=/, "", $0); print}')
 [[ "${WORKGROUP:-""}" ]] && workgroup "$WORKGROUP"
 [[ "${WIDELINKS:-""}" ]] && widelinks
 [[ "${INCLUDE:-""}" ]] && include "$INCLUDE"
+[[ "${NOFORCEUSER:-""}" ]] && noforceuser
 [[ "${PERMISSIONS:-""}" ]] && perms
 
 if [[ $# -ge 1 && -x $(which $1 2>&-) ]]; then


### PR DESCRIPTION
This adds two new options (-f and -F) which allow NOT forcing the user or group to smbuser and smb respectively. I noticed you called out in https://github.com/dperson/samba/issues/253 that you purposely were only supporting a container that supports one user for simplicity. So, if you don't want to merge this that's fine. I personally wanted the functionality so just forked your repo and implemented it. I'd prefer to use your container since you seem to keep it up to date quite often, but if you'd prefer not to merge this I can just continue to use my fork.

Thanks for implementing this. It really simplifies setting samba up. :)

P.S. - I tried to match the style you had in `samba.sh`.