### PR TITLE
Set fixed version alpine:3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.15
 MAINTAINER David Personette <dperson@gmail.com>
 
 # Install samba

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine
+FROM arm64v8/alpine:3.15
 COPY qemu-aarch64-static /usr/bin/
 MAINTAINER David Personette <dperson@gmail.com>
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine
+FROM arm32v6/alpine:3.15
 COPY qemu-arm-static /usr/bin/
 MAINTAINER David Personette <dperson@gmail.com>
 

--- a/samba.sh
+++ b/samba.sh
@@ -293,5 +293,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    exec ionice -c 3 smbd -F --no-process-group </dev/null
 fi


### PR DESCRIPTION
The `latest` images on DockerHub are based on `alpine:3.12` and contains vulnerability issues as reported in #379. Set fixed version `alpine:3.15` and rebuild/push images to fix vulnerability issues.

Executable smbd `v4.15.2` no longer accepts `-S` option (`-S, --log-stdout  Log to stdout`) in `samba.sh` and shows error `Invalid option -FS: unknown option`. For this reason, option `-S` removed.

```bash
# Apply diff, then rebuild image
$ docker build -t erriez/samba:latest .

$ docker exec -it samba-erriez_samba_1 smbd --version
Version 4.15.2

$ docker exec -it samba-erriez_samba_1 smbd --help
Usage: smbd [OPTION...]
  -b, --build-options                     Print build options
  -p, --port=STRING                       Listen on the specified ports
  -P, --profiling-level=PROFILE_LEVEL     Set profiling level

Help options:
  -?, --help                              Show this help message
      --usage                             Display brief usage message

Common Samba options:
  -d, --debuglevel=DEBUGLEVEL             Set debug level
      --debug-stdout                      Send debug output to standard output
  -s, --configfile=CONFIGFILE             Use alternative configuration file
      --option=name=value                 Set smb.conf option from command line
  -l, --log-basename=LOGFILEBASE          Basename for log/debug files
      --leak-report                       enable talloc leak reporting on exit
      --leak-report-full                  enable full talloc leak reporting on exit

Daemon options:
  -D, --daemon                            Become a daemon (default)
  -i, --interactive                       Run interactive (not a daemon) and log to stdout
  -F, --foreground                        Run daemon in foreground (for daemontools, etc.)
      --no-process-group                  Don't create a new process group

Version options:
  -V, --version                           Print version

# Scan with updated alpine:3.15 (today's report 19 December 2021)
$ docker scan erriez/samba:latest

Testing erriez/samba:latest...

Package manager:   apk
Project name:      docker-image|erriez/samba
Docker image:      erriez/samba:latest
Platform:          linux/amd64
Base image:        alpine:3.15.0

✓ Tested 64 dependencies for known vulnerabilities, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```