### PR TITLE
maintain: update samba.sh

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -293,5 +293,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    exec ionice -c 3 smbd --interactive --no-process-group </dev/null
 fi


### PR DESCRIPTION
-S: log to stdout replaced by
  -i: interactive (no-daemon+stdout)
-F is no longer needed, as -i essentially
  includes both -S and -F

Using long flags for ease of documentation.

Deprecates https://github.com/dperson/samba/pull/397
  alpine:latest is already :3.15;
  it might be a good idea to pin :3, though.