### PR TITLE
Fix startup parameter issue for samba version 4.15+

### DIFF
--- a/samba.sh
+++ b/samba.sh
@@ -293,5 +293,5 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    exec ionice -c 3 smbd -F --debug-stdout --no-process-group </dev/null
 fi


### PR DESCRIPTION
Replace parameter "S" from the "-FS" startup script to "--debug-stdout", as the "--log-stdout" parameter was replaced to "--debug-stdout" in smbd version 4.15+ as we can see [here](https://wiki.samba.org/index.php/Samba_Features_added/changed).

If we try to create a new docker image using the current dperson/samba repository and run it, the smbd service won't start. This PR fixes the startup issue caused by an inexistent parameter in the latest version, replacing it with its substitute parameter.