### PR TITLE
Added VETO environment description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ ENVIRONMENT VARIABLES
  * `USERID` - Set the UID for the samba server's default user (smbuser)
  * `GROUPID` - Set the GID for the samba server's default user (smbuser)
  * `INCLUDE` - As above, add a smb.conf include
+ * `VETO` - Configues predefined set of veto files, default:'yes' or 'no'
 
 **NOTE**: if you enable nmbd (via `-n` or the `NMBD` environment variable), you
 will also want to expose port 137 and 138 with `-p 137:137/udp -p 138:138/udp`.


### PR DESCRIPTION
When I tried to remove the veto configuration from a share I saw that the script checks the environment variable which is not described in the README.