### PR TITLE
Updated Alpine/Samba plus WSDD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM alpine
+FROM alpine:3.23.4
 LABEL maintainer="Miles Goodhew <code@m0les.com>"
 LABEL description="Modernised Samba container with wsdd (WS-Discovery)"
 
 # Install samba, wsdd, and supporting packages
-RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini tzdata samba-common-tools wsdd && \
+RUN apk --no-cache --no-progress add bash=5.3.3-r1 samba=4.22.8-r0 shadow=4.18.0-r0 tini=0.19.0-r3 tzdata=2026b-r0 wsdd=0.9-r0 && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM alpine
-MAINTAINER David Personette <dperson@gmail.com>
+LABEL maintainer="Miles Goodhew <code@m0les.com>"
+LABEL description="Modernised Samba container with wsdd (WS-Discovery)"
 
-# Install samba
+# Install samba, wsdd, and supporting packages
 RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
+    apk --no-cache --no-progress add bash samba shadow tini tzdata samba-common-tools wsdd && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \
@@ -56,8 +57,9 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
+RUN chmod +x /usr/bin/samba.sh
 
-EXPOSE 137/udp 138/udp 139 445
+EXPOSE 137/udp 138/udp 139 445 3702/udp 5357
 
 HEALTHCHECK --interval=60s --timeout=15s \
             CMD smbclient -L \\localhost -U % -m SMB3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Miles Goodhew <code@m0les.com>"
 LABEL description="Modernised Samba container with wsdd (WS-Discovery)"
 
 # Install samba, wsdd, and supporting packages
-RUN apk --no-cache --no-progress add bash=5.3.3-r1 samba=4.22.8-r0 shadow=4.18.0-r0 tini=0.19.0-r3 tzdata=2026b-r0 wsdd=0.9-r0 && \
+RUN apk --no-cache --no-progress add bash=5.3.3-r1 samba=4.22.10-r0 shadow=4.18.0-r0 tini=0.19.0-r3 tzdata=2026b-r0 wsdd=0.9-r0 && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,10 +1,10 @@
-FROM arm64v8/alpine
+FROM arm64v8/alpine.3.23.4
 COPY qemu-aarch64-static /usr/bin/
-MAINTAINER David Personette <dperson@gmail.com>
+LABEL maintainer="Miles Goodhew <code@m0les.com>"
+LABEL description="Modernised Samba container with wsdd (WS-Discovery)"
 
 # Install samba
-RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
+RUN apk --no-cache --no-progress add bash=5.3.3-r1 samba=4.22.10-r0 shadow=4.18.0-r0 tini=0.19.0-r3 tzdata=2026b-r0 wsdd=0.9-r0 && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \
@@ -57,8 +57,9 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
+RUN chmod +x /usr/bin/samba.sh
 
-EXPOSE 137/udp 138/udp 139 445
+EXPOSE 137/udp 138/udp 139 445 3702/udp 5357
 
 HEALTHCHECK --interval=60s --timeout=15s \
             CMD smbclient -L \\localhost -U % -m SMB3

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,10 +1,10 @@
-FROM arm32v6/alpine
+FROM arm32v6/alpine.3.23.4
 COPY qemu-arm-static /usr/bin/
-MAINTAINER David Personette <dperson@gmail.com>
+LABEL maintainer="Miles Goodhew <code@m0les.com>"
+LABEL description="Modernised Samba container with wsdd (WS-Discovery)"
 
 # Install samba
-RUN apk --no-cache --no-progress upgrade && \
-    apk --no-cache --no-progress add bash samba shadow tini tzdata && \
+RUN apk --no-cache --no-progress add bash=5.3.3-r1 samba=4.22.10-r0 shadow=4.18.0-r0 tini=0.19.0-r3 tzdata=2026b-r0 wsdd=0.9-r0 && \
     addgroup -S smb && \
     adduser -S -D -H -h /tmp -s /sbin/nologin -G smb -g 'Samba User' smbuser &&\
     file="/etc/samba/smb.conf" && \
@@ -57,8 +57,9 @@ RUN apk --no-cache --no-progress upgrade && \
     rm -rf /tmp/*
 
 COPY samba.sh /usr/bin/
+RUN chmod +x /usr/bin/samba.sh
 
-EXPOSE 137/udp 138/udp 139 445
+EXPOSE 137/udp 138/udp 139 445 3702/udp 5357
 
 HEALTHCHECK --interval=60s --timeout=15s \
             CMD smbclient -L \\localhost -U % -m SMB3

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ By default there are no shares configured, additional ones can be added.
 
 ## Hosting a Samba instance
 
-    sudo docker run -it -p 139:139 -p 445:445 -d dperson/samba -p
+    sudo docker run -it --net host -d dperson/samba -p
 
 OR set local storage:
 
-    sudo docker run -it --name samba -p 139:139 -p 445:445 \
+    sudo docker run -it --name samba --net host
                 -v /path/to/directory:/mount \
                 -d dperson/samba -p
 
@@ -40,6 +40,9 @@ OR set local storage:
         -i "<path>" Import smbpassword
                     required arg: "<path>" - full file path in container
         -n          Start the 'nmbd' daemon to advertise the shares
+        -d          optional: \"false\", to disable the WSDD daemon. Otherwise a
+                    list of arguments pased to wsdd verbatim e.g.
+                    "-i eth0 --no-http".
         -p          Set ownership and permissions on the shares
         -r          Disable recycle bin for shares
         -S          Disable SMB2 minimum version
@@ -96,8 +99,12 @@ ENVIRONMENT VARIABLES
 **NOTE**: if you enable nmbd (via `-n` or the `NMBD` environment variable), you
 will also want to expose port 137 and 138 with `-p 137:137/udp -p 138:138/udp`.
 
-**NOTE2**: there are reports that `-n` and `NMBD` only work if you have the
-container configured to use the hosts network stack.
+**NOTE2**: WSDD requires multicast comms, which will _only_ work if you have the
+container configured to use the host's network stack (`--net host`). You then
+won't need to specify any other port mappings (`-p` arguments), but you _will_
+need to make sure any local firewall is allowing the Samba and wsdd services
+through (e.g. for firewalld, add the "samba" and "wsdd" services to the default
+interface).
 
 **NOTE3**: optionally supports additional variables starting with the same name,
 IE `SHARE` also will work for `SHARE2`, `SHARE3`... `SHAREx`, etc.

--- a/samba.sh
+++ b/samba.sh
@@ -184,20 +184,13 @@ widelinks() { local file=/etc/samba/smb.conf \
 }
 
 ### start_wsdd: launch wsdd in the background
-#
-# wsdd announces the host via WS-Discovery (UDP 3702 / TCP 5357) so Windows
-# 10/11 clients can browse it in Network without needing NetBIOS / nmbd.
-#
 # Arguments:
-#   none)
+#   wsdd_opts) "false" to disable wsdd; or an optional list of arguments
+#              to pass to wsdd verbatim e.g. "-i eth0 --no-http".
 # Return:
 #   none)
-# Environment variables:
-#   WSDD_OPTS   - set to "false" to disable or optionally can contain extra
-#               CLI options forwarded to wsdd verbatim e.g. WSDD_OPTS="-i
-#               eth0 --no-http"
-start_wsdd() {
-    [[ "${WSDD_OPTS:-true}" == "false" ]] && return 0
+start_wsdd() { local wsdd_opts="$1"
+    [[ "${wsdd_opts:-true}" == "false" ]] && return 0
 
     # Derive the workgroup from smb.conf so wsdd announces the same one
     local wg
@@ -207,7 +200,7 @@ start_wsdd() {
     echo -- "Starting wsdd (workgroup=${wg:-}) ${WSDD_OPTS:-}"
     ionice -c 3 wsdd \
         ${wg:+--workgroup "$wg"} \
-        ${WSDD_OPTS:-} \
+        ${wsdd_opts:-} \
         2>&1 | while IFS= read -r line; do echo "[wsdd] $line"; done &
 }
 
@@ -229,8 +222,9 @@ Options (fields in '[]' are optional, '<>' are required):
     -i \"<path>\" Import smbpassword
                 required arg: \"<path>\" - full file path in container
     -n          Start the 'nmbd' daemon to advertise the shares
-    -d          optional: if \"false\", then DO NOT run the WSDD daemon.
-                Otherwise can contain arguments pased to the WSDD daemon.
+    -d          optional: \"false\", to disable the WSDD daemon. Otherwise a
+                list of arguments pased to wsdd verbatim e.g.
+		"-i eth0 --no-http".
     -p          Set ownership and permissions on the shares
     -r          Disable recycle bin for shares
     -S          Disable SMB2 minimum version
@@ -324,6 +318,6 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    start_wsdd
+    start_wsdd "${WSDD_OPTS:-}"
     exec ionice -c 3 smbd -F --no-process-group </dev/null
 fi

--- a/samba.sh
+++ b/samba.sh
@@ -190,36 +190,23 @@ widelinks() { local file=/etc/samba/smb.conf \
 # 10/11 clients can browse it in Network without needing NetBIOS / nmbd.
 #
 # Relevant environment variables:
-#   WSDD      - set to "no" to disable (default: enabled)
-#   WSDD_OPTS - extra CLI options forwarded to wsdd verbatim
-#               e.g. WSDD_OPTS="-i eth0 --no-http"
+#   WSDD_OPTS   - set to "false" to disable or optionally can contain extra
+#               CLI options forwarded to wsdd verbatim e.g. WSDD_OPTS="-i
+#               eth0 --no-http"
 # ---------------------------------------------------------------------------
 start_wsdd() {
-    # Honour explicit opt-out
-    [[ "${WSDD:-yes}" == "no" ]] && return 0
-
-    if ! command -v wsdd &>/dev/null; then
-        echo "WARNING: wsdd binary not found — skipping WS-Discovery" >&2
-        return 0
-    fi
+    [[ "${WSDD_OPTS:-true}" == "false" ]] && return 0
 
     # Derive the workgroup from smb.conf so wsdd announces the same one
     local wg
     wg=$(awk -F '=' '/^\s*workgroup\s*=/ {gsub(/\s/,"",$2); print $2; exit}' \
          /etc/samba/smb.conf)
-    wg="${wg:-WORKGROUP}"
 
-    echo "Starting wsdd (workgroup=$wg) ${WSDD_OPTS:-}"
-    # Run with ionice class 3 (idle) so it doesn't compete with smbd for I/O.
-    # Redirect stdout/stderr to container stdout so logs are visible via
-    # `podman logs`.
+    echo -- "Starting wsdd (workgroup=${wg:-}) ${WSDD_OPTS:-}"
     ionice -c 3 wsdd \
-        --workgroup "$wg" \
+        ${wg:+--workgroup "$wg"} \
         ${WSDD_OPTS:-} \
         2>&1 | while IFS= read -r line; do echo "[wsdd] $line"; done &
-
-    WSDD_PID=$!
-    echo "wsdd started (PID $WSDD_PID)"
 }
 
 ### usage: Help
@@ -240,6 +227,8 @@ Options (fields in '[]' are optional, '<>' are required):
     -i \"<path>\" Import smbpassword
                 required arg: \"<path>\" - full file path in container
     -n          Start the 'nmbd' daemon to advertise the shares
+    -d          optional: if \"false\", then DO NOT run the WSDD daemon.
+                Otherwise can contain arguments pased to the WSDD daemon.
     -p          Set ownership and permissions on the shares
     -r          Disable recycle bin for shares
     -S          Disable SMB2 minimum version
@@ -272,10 +261,6 @@ Options (fields in '[]' are optional, '<>' are required):
                 required arg: \"<include file path>\"
                 <include file path> in the container, e.g. a bind mount
 
-Environment variables:
-    WSDD        Set to "no" to disable wsdd / WS-Discovery (default: enabled)
-    WSDD_OPTS   Extra flags passed verbatim to wsdd, e.g. "-i eth0"
-
 The 'command' (if provided and valid) will be run instead of samba
 " >&2
     exit $RC
@@ -284,7 +269,7 @@ The 'command' (if provided and valid) will be run instead of samba
 [[ "${USERID:-""}" =~ ^[0-9]+$ ]] && usermod -u $USERID -o smbuser
 [[ "${GROUPID:-""}" =~ ^[0-9]+$ ]] && groupmod -g $GROUPID -o smb
 
-while getopts ":hc:G:g:i:nprs:Su:Ww:I:" opt; do
+while getopts ":hc:G:g:i:nd:prs:Su:Ww:I:" opt; do
     case "$opt" in
         h) usage ;;
         c) charmap "$OPTARG" ;;
@@ -292,6 +277,7 @@ while getopts ":hc:G:g:i:nprs:Su:Ww:I:" opt; do
         g) global "$OPTARG" ;;
         i) import "$OPTARG" ;;
         n) NMBD="true" ;;
+	d) WSDD_OPTS="$OPTARG" ;;
         p) PERMISSIONS="true" ;;
         r) recycle ;;
         s) eval share $(sed 's/^/"/; s/$/"/; s/;/" "/g' <<< $OPTARG) ;;
@@ -336,8 +322,6 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    # Start wsdd for modern WS-Discovery (Windows Network visibility)
     start_wsdd
-    # NOTE: "-S" flag (log to stdout) removed in Samba v4.15
     exec ionice -c 3 smbd -F --no-process-group </dev/null
 fi

--- a/samba.sh
+++ b/samba.sh
@@ -183,17 +183,19 @@ widelinks() { local file=/etc/samba/smb.conf \
     sed -i 's/\(follow symlinks = yes\)/'"$replace"'/' $file
 }
 
-# ---------------------------------------------------------------------------
-# start_wsdd: launch wsdd in the background
+### start_wsdd: launch wsdd in the background
 #
 # wsdd announces the host via WS-Discovery (UDP 3702 / TCP 5357) so Windows
 # 10/11 clients can browse it in Network without needing NetBIOS / nmbd.
 #
-# Relevant environment variables:
+# Arguments:
+#   none)
+# Return:
+#   none)
+# Environment variables:
 #   WSDD_OPTS   - set to "false" to disable or optionally can contain extra
 #               CLI options forwarded to wsdd verbatim e.g. WSDD_OPTS="-i
 #               eth0 --no-http"
-# ---------------------------------------------------------------------------
 start_wsdd() {
     [[ "${WSDD_OPTS:-true}" == "false" ]] && return 0
 

--- a/samba.sh
+++ b/samba.sh
@@ -183,6 +183,45 @@ widelinks() { local file=/etc/samba/smb.conf \
     sed -i 's/\(follow symlinks = yes\)/'"$replace"'/' $file
 }
 
+# ---------------------------------------------------------------------------
+# start_wsdd: launch wsdd in the background
+#
+# wsdd announces the host via WS-Discovery (UDP 3702 / TCP 5357) so Windows
+# 10/11 clients can browse it in Network without needing NetBIOS / nmbd.
+#
+# Relevant environment variables:
+#   WSDD      - set to "no" to disable (default: enabled)
+#   WSDD_OPTS - extra CLI options forwarded to wsdd verbatim
+#               e.g. WSDD_OPTS="-i eth0 --no-http"
+# ---------------------------------------------------------------------------
+start_wsdd() {
+    # Honour explicit opt-out
+    [[ "${WSDD:-yes}" == "no" ]] && return 0
+
+    if ! command -v wsdd &>/dev/null; then
+        echo "WARNING: wsdd binary not found — skipping WS-Discovery" >&2
+        return 0
+    fi
+
+    # Derive the workgroup from smb.conf so wsdd announces the same one
+    local wg
+    wg=$(awk -F '=' '/^\s*workgroup\s*=/ {gsub(/\s/,"",$2); print $2; exit}' \
+         /etc/samba/smb.conf)
+    wg="${wg:-WORKGROUP}"
+
+    echo "Starting wsdd (workgroup=$wg) ${WSDD_OPTS:-}"
+    # Run with ionice class 3 (idle) so it doesn't compete with smbd for I/O.
+    # Redirect stdout/stderr to container stdout so logs are visible via
+    # `podman logs`.
+    ionice -c 3 wsdd \
+        --workgroup "$wg" \
+        ${WSDD_OPTS:-} \
+        2>&1 | while IFS= read -r line; do echo "[wsdd] $line"; done &
+
+    WSDD_PID=$!
+    echo "wsdd started (PID $WSDD_PID)"
+}
+
 ### usage: Help
 # Arguments:
 #   none)
@@ -232,6 +271,10 @@ Options (fields in '[]' are optional, '<>' are required):
     -I          Add an include option at the end of the smb.conf
                 required arg: \"<include file path>\"
                 <include file path> in the container, e.g. a bind mount
+
+Environment variables:
+    WSDD        Set to "no" to disable wsdd / WS-Discovery (default: enabled)
+    WSDD_OPTS   Extra flags passed verbatim to wsdd, e.g. "-i eth0"
 
 The 'command' (if provided and valid) will be run instead of samba
 " >&2
@@ -293,5 +336,8 @@ elif ps -ef | egrep -v grep | grep -q smbd; then
     echo "Service already running, please restart container to apply changes"
 else
     [[ ${NMBD:-""} ]] && ionice -c 3 nmbd -D
-    exec ionice -c 3 smbd -FS --no-process-group </dev/null
+    # Start wsdd for modern WS-Discovery (Windows Network visibility)
+    start_wsdd
+    # NOTE: "-S" flag (log to stdout) removed in Samba v4.15
+    exec ionice -c 3 smbd -F --no-process-group </dev/null
 fi


### PR DESCRIPTION
This was borne out of a desire to use the dperson/samba Docker image with "modern" Windows clients (10/11).
This requires both an updated Samba version and also the ability to do Windows Service Discovery (WSD). While we wait to see if Samba integrates WSD, the [wsdd](https://github.com/christgau/wsdd) script will fill the gap. Fortunately all this is available as Alpine packages, so I make a fork to pin to a specific known-working combination of all software versions (for deterministic builds).

# Effective changes from the base version
- wsdd daemon added to the installed package list
- OS and all installed packages pinned to specific versions (plus no package-update in the build) - this is all to ensure determinism.
- WSDD uses serving multicast traffic, which requires access to the host network (`--net host`)
- Added a new `-d` flag to either disable wsdd (if given an optarg of `false`), or to pass any optional parameters to the wsdd daemon otherwise.
- Runs a `chmod +x` on the `samba.sh` script in the container to be able to start it from tini.
- Runs `wsdd` in `samba.sh` just before `smbd`
- Removed the `-S` parameter to `smbd`, as this was deprecated in Samba v4.15 (Was: "log to stdout")

# Things to note:
- The `wsdd` service requires serving multicast data. As best I can determine, Linux containers can only work with multicast if they are directly connected to the host network (`--net host`). While there's lots of mentions of opening ports (`-p nn:nn`) and the actual `smbd` service will still work that way, the service won't be _discoverable_ by Windows clients without the `wsdd` service working properly (i.e. the serving host won't show-up automatically in the File Explorer's "Network" view). I'm far from being a container networking expert and I only have an IPV4 local network to test with. So it's entirely possible someone might be able to figure-out a more restrictive way to map ports for multicast (but it isn't going to be me).
- The initial cut of this was developed through an Anthropic/Claude query. The results were only slightly broken/delusional (one missed breaking-change in `smbd` and one hallucinated `wsdd` parameter). However the result was also a reasonably large diff as it added a bunch of minor coding improvements, style changes and in-line documentation. I spent considerable effort "minimising" the diff and converting it to something that seemed to fit the original repo's coding style better. I believe I've achieved the bare minimum diff now. Ultimately I think there's only one or two lines left that I would attribute to the AI's original output (some variable and output handling). I don't really consider this "vibe coding" (because I understand everything it did and trimmed-out or reshaped it anyway), but you may have your own ideas about it, so you have all the information you need to make your own decision.
- Although I've updated the Dockerfile's "maintainer" information to implicate myself instead of David Personette, I don't have any plans to support/maintain this in the future. I might roll-out new builds with updated OS or repository packages, but I don't plan on making any other changes to this repo's code. My ideal is anything "good" in here could be merged into the base repository (however, I don't have any expectation or entitlement to that).
- Although the original repo is pretty "Docker-specific", I worked on this using only Podman (on a Fedora 44 host). I can't see this causing issues for Docker users, but I've done no testing to prove this.
- As mentioned in the changes section, this build now pins the versions of the Alpine image as well as all the installed packages (as well as removing the package update in the build). The intention to to make a deterministic container image. While this ensures compatibility between all the software components _in_ the image, it increases the risk of _incompatibility_ with newer clients and also the risk of latent security issues. I'd expect that _if_ I ever produce newer releases of this repo and images built from it, I'd be updating some of these pinned versions to later ones (and not much else).